### PR TITLE
Add missing facebook permissions

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -40,6 +40,8 @@
                             });
                         })
                         .catch(error => console.log('Login', error));
+                }, {
+                    scope: 'manage_pages,pages_messaging'
                 });
 
             })


### PR DESCRIPTION
This sample only works if you happen to have already granted your test Facebook app `manage_pages` and `pages_messaging` permissions via some other means.

Without these permissions, this sample fails quietly :O You can reproduce this issue by first going here https://www.facebook.com/settings?tab=business_tools and revoking any existing granted permissions.